### PR TITLE
Enable them build containers with the buildpacks

### DIFF
--- a/services/customer-async/Dockerfile
+++ b/services/customer-async/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn google-cloud-datastore
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/customer-async/requirements.txt
+++ b/services/customer-async/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+google-cloud-datastore

--- a/services/customer-sync/Dockerfile
+++ b/services/customer-sync/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn google-cloud-datastore
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/customer-sync/requirements.txt
+++ b/services/customer-sync/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+google-cloud-datastore

--- a/services/event-publisher/Dockerfile
+++ b/services/event-publisher/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn google-cloud-datastore google-cloud-pubsub 
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/event-publisher/requirements.txt
+++ b/services/event-publisher/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+gunicorn
+google-cloud-datastore
+google-cloud-pubsub

--- a/services/order-async/Dockerfile
+++ b/services/order-async/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn google-cloud-datastore
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/order-async/requirements.txt
+++ b/services/order-async/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+google-cloud-datastore

--- a/services/order-processor/Dockerfile
+++ b/services/order-processor/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn requests
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/order-processor/requirements.txt
+++ b/services/order-processor/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+requests

--- a/services/order-sync/Dockerfile
+++ b/services/order-sync/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn google-cloud-datastore
+RUN pip install -r requirements.txt
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/services/order-sync/requirements.txt
+++ b/services/order-sync/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+gunicorn
+google-cloud-datastore


### PR DESCRIPTION
It will be happy for developers to build container with the buildpacks, in addition to the standard way with a Dockerfile.
The buildpacks for Python need a requirements.txt to find out the required modules, that's why I modified a little.